### PR TITLE
MAINT: Add Github Action to CI

### DIFF
--- a/.github/workflows/football_simulation_app.yml
+++ b/.github/workflows/football_simulation_app.yml
@@ -1,0 +1,41 @@
+name: Python application
+
+on: [push]
+
+jobs:
+  build:
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [ubuntu-latest]
+
+    steps:
+    - uses: actions/checkout@v2
+
+    - name: Build venv environment
+      run: |
+        python3 -m venv .venv
+        source .venv/bin/activate
+
+    - name: Install dependencies and package
+      run: |
+        echo "Install"
+        pip install -U -e .[develop]
+
+    - name: Prelimiary tests
+      run:
+        echo "Check Compile"
+        python -m compileall src/football/
+
+    - name: Type check with mypy
+      run:
+        echo "Check type stuff"
+        mypy src/football/
+
+    - name: Linting with Pylint
+      run:
+        pylint src/football
+
+    - name: Test with pytest and generate coverage report
+      run:
+        pytest --cov=football --cov-report html tests/

--- a/.github/workflows/football_simulation_app.yml
+++ b/.github/workflows/football_simulation_app.yml
@@ -34,7 +34,7 @@ jobs:
 
     - name: Linting with Pylint
       run:
-        pylint src/football
+        pylint --fail-under=9 src/football
 
     - name: Test with pytest and generate coverage report
       run:

--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@ __pycache__/
 htmlcov
 .venv/
 **/*egg-info/
+.idea/


### PR DESCRIPTION
Adds a GitHub Action workflow that performs the same processes as `fm_test.sh` for an Ubuntu build. A minimum score of 9 is added to the Pylint check so that it doesn't fail the CI if a perfect 10 is not achieved.

Also includes PyCharm project files (`.idea/`) in the gitignore